### PR TITLE
Fix missing StartAutoHunt flag

### DIFF
--- a/constinfo.py
+++ b/constinfo.py
@@ -193,6 +193,11 @@ SEQUENCE_PACKET_ENABLE = 1
 KEEP_ACCOUNT_CONNETION_ENABLE = 1
 MINIMAP_POSITIONINFO_ENABLE = 1
 
+# Flag for Auto Hunt mode
+StartAutoHunt = 0
+
+autohunt_bonus = 0
+
 isItemQuestionDialog = 0
 
 def GET_ITEM_QUESTION_DIALOG_STATUS():


### PR DESCRIPTION
## Summary
- add `StartAutoHunt` and `autohunt_bonus` flags to `constinfo`

## Testing
- `python -m py_compile myhunt.py uiautohunt.py constinfo.py` *(fails: invalid decimal literal)*


------
https://chatgpt.com/codex/tasks/task_e_684d3fcf38e88330b4f4314cc26a23c9